### PR TITLE
Display the name of short invites properly

### DIFF
--- a/retroshare-gui/src/gui/connect/ConnectFriendWizard.cpp
+++ b/retroshare-gui/src/gui/connect/ConnectFriendWizard.cpp
@@ -599,7 +599,7 @@ void ConnectFriendWizard::initializePage(int id)
 			if(mIsShortInvite)
 			{
 				if(ui->nameEdit->text().isEmpty())
-					ui->nameEdit->setText(tr("[Unknown]"));
+					ui->nameEdit->setText(QString::fromUtf8(peerDetails.name.c_str()));
 				ui->addKeyToKeyring_CB->setChecked(false);
 				ui->addKeyToKeyring_CB->setEnabled(false);
 				ui->signersEdit->hide();


### PR DESCRIPTION
Instead of [Unknown], since the name is actually in the short invite.

This is what is shown on my setup now when adding a user's short invite:
![image](https://user-images.githubusercontent.com/4717816/152651656-3300c7d6-831c-4868-b04d-41bd361298ba.png)
